### PR TITLE
Various fixes

### DIFF
--- a/artifact.nix
+++ b/artifact.nix
@@ -143,6 +143,7 @@ stdenv.mkDerivation rec {
   passthru = {
     targetPrefix = "";
     enableShared = true;
+    haskellCompilerName = "ghc-999.9";
   };
 
   meta.license = stdenv.lib.licenses.bsd3;

--- a/artifact.nix
+++ b/artifact.nix
@@ -1,7 +1,7 @@
 { stdenv
-, fetchurl, perl, gcc, llvm_39
+, perl, gcc, llvm_39
 , ncurses5, gmp, glibc, libiconv
-}: {branch ? "master", fork ? "ghc" }:
+}: { bindistTarball }:
 
 # Prebuilt only does native
 assert stdenv.targetPlatform == stdenv.hostPlatform;
@@ -21,8 +21,6 @@ let
     else
       "${stdenv.lib.getLib glibc}/lib/ld-linux*";
 
-  mkUrl = job: "https://gitlab.haskell.org/${fork}/ghc/-/jobs/artifacts/${branch}/raw/ghc.tar.xz?job=${job}";
-
 in
 
 stdenv.mkDerivation rec {
@@ -30,21 +28,7 @@ stdenv.mkDerivation rec {
 
   name = "ghc-${version}-binary";
 
-  src = builtins.fetchurl ({
-    "i386-linux"   = {
-      url = mkUrl "validate-i386-linux-deb9";
-    };
-    "x86_64-linux" = {
-      url = mkUrl "validate-x86_64-linux-deb8";
-    };
-    "aarch64-linux" = {
-      url = mkUrl "validate-aarch64-linux-deb9";
-    };
-    "x86_64-darwin" = {
-      url = mkUrl "validate-x86_64-darwin";
-    };
-  }.${stdenv.hostPlatform.system}
-    or (throw "cannot bootstrap GHC on this platform"));
+  src = bindistTarball;
 
   nativeBuildInputs = [ perl ];
   buildInputs = stdenv.lib.optionals (stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64) [ llvm_39 ];

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,11 @@
 let
   np = import <nixpkgs> {};
   ghc = self: ref: self.callPackage ./artifact.nix {} ref;
-  ol = self: super: { ghcHEAD = ghc self { inherit fork branch; }; };
+  ol = self: super:
+    {
+      ghcHEAD = ghc self {
+        bindistTarball = self.callPackage ./gitlab-artifact.nix {} { inherit fork branch; };
+      };
+    };
 in
   import <nixpkgs> { overlays = [ol]; }

--- a/default.nix
+++ b/default.nix
@@ -4,9 +4,10 @@ let
   ghc = self: ref: self.callPackage ./artifact.nix {} ref;
   ol = self: super:
     {
-      ghcHEAD = ghc self {
-        bindistTarball = self.callPackage ./gitlab-artifact.nix {} { inherit fork branch; };
-      };
+      ghcHEAD =
+        ghc self (self.callPackage ./gitlab-artifact.nix {} {
+          inherit fork branch;
+        });
     };
 in
   import <nixpkgs> { overlays = [ol]; }

--- a/gitlab-artifact.nix
+++ b/gitlab-artifact.nix
@@ -1,0 +1,22 @@
+{ stdenv }:
+{ branch, fork }:
+
+let
+  mkUrl = job: "https://gitlab.haskell.org/${fork}/ghc/-/jobs/artifacts/${branch}/raw/ghc.tar.xz?job=${job}";
+  url = {
+    "i386-linux"   = {
+      url = mkUrl "validate-i386-linux-deb9";
+    };
+    "x86_64-linux" = {
+      url = mkUrl "validate-x86_64-linux-deb8";
+    };
+    "aarch64-linux" = {
+      url = mkUrl "validate-aarch64-linux-deb9";
+    };
+    "x86_64-darwin" = {
+      url = mkUrl "validate-x86_64-darwin";
+    };
+  }.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform");
+in builtins.fetchurl url
+

--- a/gitlab-artifact.nix
+++ b/gitlab-artifact.nix
@@ -3,20 +3,33 @@
 
 let
   mkUrl = job: "https://gitlab.haskell.org/${fork}/ghc/-/jobs/artifacts/${branch}/raw/ghc.tar.xz?job=${job}";
-  url = {
+
+  # job: the GitLab CI job we should pull the bindist from
+  # ncursesVersion: the ncurses version which the bindist expects
+  configs = {
     "i386-linux"   = {
-      url = mkUrl "validate-i386-linux-deb9";
+      job = mkUrl "validate-i386-linux-fedora27";
+      ncursesVersion = "6";
     };
     "x86_64-linux" = {
-      url = mkUrl "validate-x86_64-linux-deb8";
+      job = mkUrl "validate-x86_64-linux-fedora27";
+      ncursesVersion = "6";
     };
     "aarch64-linux" = {
-      url = mkUrl "validate-aarch64-linux-deb9";
+      job = mkUrl "validate-aarch64-linux-deb9";
+      ncursesVersion = "5";
     };
     "x86_64-darwin" = {
-      url = mkUrl "validate-x86_64-darwin";
+      job = mkUrl "validate-x86_64-darwin";
+      ncursesVersion = "6";
     };
-  }.${stdenv.hostPlatform.system}
+  };
+
+  config = configs.${stdenv.hostPlatform.system}
     or (throw "cannot bootstrap GHC on this platform");
-in builtins.fetchurl url
+
+in {
+  bindistTarball = builtins.fetchurl (mkUrl config.job);
+  inherit (config) ncursesVersion;
+}
 


### PR DESCRIPTION
A few things:

 * Expose `haskellCompilerName` and the correct version computed from the bindist, allowing the compiler to be used with `cabal2nix`
 * Factor out the tarball URL computation, which I found helpful while debugging.