### PR TITLE
Fix version dumping logic

### DIFF
--- a/artifact.nix
+++ b/artifact.nix
@@ -34,6 +34,8 @@ let
         src = bindistTarball;
         nativeBuildInputs = [ gcc perl ];
         buildPhase = ''
+          # Run it twice since make might produce related output the first time.
+          make show VALUE=ProjectVersion
           make show VALUE=ProjectVersion > version
         '';
         installPhase = ''


### PR DESCRIPTION
It seems like `make show` now runs some builds before producing the
output we want. Run it twice to ensure the output from these builds
doesn't break things.