### PR TITLE
Fix references to libtinfo in installed package database

### DIFF
--- a/artifact.nix
+++ b/artifact.nix
@@ -148,6 +148,17 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  postInstall = stdenv.lib.optionalString stdenv.isLinux ''
+    # Fix dependencies on libtinfo in package registrations.
+    for f in $(find "$out" -type f -iname '*.conf'); do
+        echo "Fixing tinfo dependency in $f..."
+        #sed -i "s/extra-libraries: *tinfo/extra-libraries: ncurses\n/" $f
+        echo "library-dirs: ${selectedNcurses}/lib" >> $f
+        echo "dynamic-library-dirs: ${selectedNcurses}/lib" >> $f
+    done
+    $out/bin/ghc-pkg recache
+  '';
+
   doInstallCheck = true;
   installCheckPhase = ''
     unset ${libEnvVar}

--- a/ghc-head-from.sh
+++ b/ghc-head-from.sh
@@ -1,4 +1,10 @@
 #! /usr/bin/env bash
+
+default_nix=https://github.com/mpickering/ghc-artefact-nix/archive/master.tar.gz
+if [ -f $(dirname $0)/default.nix ]; then
+  default_nix=$(dirname $0)
+fi
+
 re='^[0-9]+$'
 if [[ $1 =~ $re ]] ;
 then
@@ -13,7 +19,7 @@ then
 elif ! [ -z "$1" ]; then
   # Assume the argument is a URL
   echo "Fetching artefact from $1"
-  nix run -f https://github.com/mpickering/ghc-artefact-nix/archive/master.tar.gz \
+  nix run -f $default_nix \
     --argstr url $1 \
     ghcHEAD cabal-install gcc binutils-unwrapped
   exit 0
@@ -22,7 +28,7 @@ fi
 FORK=''${PARSED_FORK:-ghc}
 BRANCH=''${PARSED_BRANCH:-master}
 echo "Fetching artefact from $FORK/$BRANCH"
-nix run -f https://github.com/mpickering/ghc-artefact-nix/archive/master.tar.gz \
+nix run -f $default_nix \
   --argstr fork $FORK \
   --argstr branch $BRANCH \
    ghcHEAD cabal-install gcc binutils-unwrapped


### PR DESCRIPTION
This allows packages built with the compiler to be linked.