### PR TITLE
Take nixpkgsSrc as an argument

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
-{ branch ? "master", fork ? "ghc", url ? null, ncursesVersion ? "6" }:
+{ branch ? "master", fork ? "ghc", url ? null, ncursesVersion ? "6", nixpkgsSrc ? <nixpkgs> }:
 let
-  np = import <nixpkgs> {};
   ghc = self: ref: self.callPackage ./artifact.nix {} ref;
 
   gitlabConfig = self: (self.callPackage ./gitlab-artifact.nix {} {
@@ -17,4 +16,4 @@ let
       ghc-head-from = self.callPackage ./ghc-head-from.nix {};
     };
 in
-  import <nixpkgs> { overlays = [ol]; }
+  import nixpkgsSrc { overlays = [ol]; }


### PR DESCRIPTION
Otherwise you can end up in situations with inconsistent `nixpkgs` versions relying on different `glibc` versions, resulting in breakage (e.g. https://gitlab.haskell.org/ghc/head.hackage/-/jobs/624785).